### PR TITLE
위치 정보 못 가져온경우 오류 메시지 띄우고 위치 업데이트 요청 안하도록 수정

### DIFF
--- a/app/src/main/java/com/cookandroid/capstone_front_android/jmap.java
+++ b/app/src/main/java/com/cookandroid/capstone_front_android/jmap.java
@@ -69,13 +69,32 @@ public class jmap extends Fragment implements OnMapReadyCallback, GoogleMap.OnMa
         if(location == null){
             location = lm.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
         }
-        provider = location.getProvider();
-        longitude = location.getLongitude();
-        latitude = location.getLatitude();
-        text.setText("위치정보 : " + provider + "\n" + "위도 : " + longitude + "\n" + "경도 : " + latitude);
 
-        lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1000, 1, gpsLocationListener);
-        lm.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 1000, 1, gpsLocationListener);
+        // last known location 이 위치를 제대로 가져왔는지 확인
+        if(location == null) { // 위치 확인 안 되는 경우
+            Toast.makeText(getActivity(), "마지막 위치 가져오기 실패", Toast.LENGTH_SHORT).show();
+
+            //location = new Location(LocationManager.NETWORK_PROVIDER);
+            provider = "null";
+            longitude = 0;
+            latitude = 0;
+            text.setText("위치정보 확인 불가");
+        } else { // 위치 확인 성공한 경우
+            provider = location.getProvider();
+            longitude = location.getLongitude();
+            latitude = location.getLatitude();
+            text.setText("위치정보 : " + provider + "\n" + "위도 : " + longitude + "\n" + "경도 : " + latitude);
+
+            lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1000, 1, gpsLocationListener);
+            lm.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 1000, 1, gpsLocationListener);
+        }
+
+        /*try {
+            lm.requestLocationUpdates(LocationManager.GPS_PROVIDER, 1000, 1, gpsLocationListener);
+            lm.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 1000, 1, gpsLocationListener);
+        } catch(IllegalArgumentException e) {
+            Toast.makeText(getActivity(), "위치 업데이트 실패", Toast.LENGTH_SHORT).show();
+        }*/
 
         sView = (MapView) view.findViewById(R.id.sMap);
         sView.onCreate(savedInstanceState);

--- a/app/src/main/java/com/cookandroid/capstone_front_android/network/RetrofitClient.java
+++ b/app/src/main/java/com/cookandroid/capstone_front_android/network/RetrofitClient.java
@@ -11,7 +11,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class RetrofitClient {
-    public final static String BASE_URL = "http://192.168.25.30:8080";
+    public final static String BASE_URL = "http://192.168.0.25:8080";
 
     // 로그인 인터셉터를 탑재하기 위한 OkHttp 클라이언트 제작 메소드
     private static OkHttpClient provideOkHttpClient(LoginInterceptor loginInterceptor) {


### PR DESCRIPTION
GPS_PROVIDER, NETWORK_PROVIDER 모두 제대로 작동하지 않는 환경에서 로그인 시 안 넘어가고 튕기는 문제 해결

requestLocationUpdates이 위치를 가져오지 못하고 null 반환 -> getProvider, getLongitude, getLatitude에서 nullPointerException 발생 -> "null", 0, 0으로 지정

requestLocationUpdates에서도 provider 문제 발생 -> 가져온 location이 null인 경우 호출X

정상적인 경우(location != null인 경우)에는 기존과 동일